### PR TITLE
Add support for providing ETag and If-Modified-Since

### DIFF
--- a/src/WebDav.Client/ApiParams/GetFileParameters.cs
+++ b/src/WebDav.Client/ApiParams/GetFileParameters.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 
 namespace WebDav
 {
@@ -19,5 +20,15 @@ namespace WebDav
         /// Gets or sets the cancellation token.
         /// </summary>
         public CancellationToken CancellationToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the quoted ETag string use by the If-None-Match HTTP header.
+        /// </summary>
+        public string ETag { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value of the If-Modified-Since HTTP header.
+        /// </summary>
+        public DateTimeOffset? IfModifiedSince { get; set; }
     }
 }

--- a/src/WebDav.Client/Infrastructure/HttpResponse.cs
+++ b/src/WebDav.Client/Infrastructure/HttpResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 
 namespace WebDav.Infrastructure
 {
@@ -14,9 +15,14 @@ namespace WebDav.Infrastructure
             Content = content;
             StatusCode = statusCode;
             Description = description;
+            LastModified = content?.Headers?.LastModified;
         }
 
         public HttpContent Content { get; }
+
+        public string ETag { get; internal set; }
+
+        public DateTimeOffset? LastModified { get; }
 
         public int StatusCode { get; }
 

--- a/src/WebDav.Client/Infrastructure/WebDavDispatcher.cs
+++ b/src/WebDav.Client/Infrastructure/WebDavDispatcher.cs
@@ -35,7 +35,9 @@ namespace WebDav.Infrastructure
                 }
 
                 var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-                return new HttpResponse(response.Content, (int)response.StatusCode, response.ReasonPhrase);
+                return new HttpResponse(response.Content, (int)response.StatusCode, response.ReasonPhrase) {
+                    ETag = response?.Headers?.ETag?.Tag
+                };
             }
         }
 

--- a/src/WebDav.Client/Response/WebDavStreamResponse.cs
+++ b/src/WebDav.Client/Response/WebDavStreamResponse.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace WebDav
 {
@@ -47,6 +48,10 @@ namespace WebDav
         {
             Stream = stream;
         }
+
+        public string ETag { get; internal set; }
+
+        public DateTimeOffset? LastModified { get; internal set; }
 
         /// <summary>
         /// Gets the stream of content of the resource.


### PR DESCRIPTION
This allows the server to return a 304 Not Modified response if the requested file hasn't been modified.

I've made sure not to change any constructor signatures, so in some cases I've had to add internal setters. Hopefully the code style isn't too different.