### PR TITLE
Add AllPropertiesImplied option

### DIFF
--- a/src/WebDav.Client/Core/PropfindRequestType.cs
+++ b/src/WebDav.Client/Core/PropfindRequestType.cs
@@ -8,6 +8,11 @@
     public enum PropfindRequestType
     {
         AllProperties,
-        NamedProperties
+        NamedProperties,
+
+        /// <summary>
+        /// Don't pass a body
+        /// </summary>
+        AllPropertiesImplied,
     }
 }

--- a/src/WebDav.Client/WebDavClient.cs
+++ b/src/WebDav.Client/WebDavClient.cs
@@ -103,8 +103,11 @@ namespace WebDav
                 .AddWithOverwrite(parameters.Headers)
                 .Build();
 
-            var requestBody = PropfindRequestBuilder.BuildRequest(parameters.RequestType, parameters.CustomProperties, parameters.Namespaces);
-            var requestParams = new RequestParameters { Headers = headers, Content = new StringContent(requestBody) };
+            HttpContent requestBody = parameters.RequestType == PropfindRequestType.AllPropertiesImplied
+                ? null
+                : new StringContent(PropfindRequestBuilder.BuildRequest(parameters.RequestType, parameters.CustomProperties, parameters.Namespaces));
+
+            var requestParams = new RequestParameters { Headers = headers, Content = requestBody };
             var response = await _dispatcher.Send(requestUri, WebDavMethod.Propfind, requestParams, parameters.CancellationToken).ConfigureAwait(false);
             var responseContent = await ReadContentAsString(response.Content).ConfigureAwait(false);
             return _propfindResponseParser.Parse(responseContent, (int)response.StatusCode, response.ReasonPhrase);


### PR DESCRIPTION
Allows interacting with a WebDAV server that returns the wrong response if there is any request body.  Per the spec, no body is implied as `AllProperties`.