### PR TITLE
Changing default request type to application/xml and allowing to override it

### DIFF
--- a/src/WebDav.Client.Tests/Methods/PutFileTests.cs
+++ b/src/WebDav.Client.Tests/Methods/PutFileTests.cs
@@ -123,9 +123,9 @@ namespace WebDav.Client.Tests.Methods
             var dispatcher = Dispatcher.Mock();
             var client = new WebDavClient().SetWebDavDispatcher(dispatcher);
 
-            await client.PutFile(requestUri, stream, new PutFileParameters { ContentType = "text/xml" });
+            await client.PutFile(requestUri, stream, new PutFileParameters { ContentType = new MediaTypeHeaderValue("text/xml") });
             await dispatcher.Received(1)
-                .Send(requestUri, HttpMethod.Put, Arg.Is<RequestParameters>(x => x.ContentType == "text/xml"), CancellationToken.None);
+                .Send(requestUri, HttpMethod.Put, Arg.Is<RequestParameters>(x => x.ContentType.MediaType == "text/xml"), CancellationToken.None);
         }
     }
 }

--- a/src/WebDav.Client/Core/MediaTypes.cs
+++ b/src/WebDav.Client/Core/MediaTypes.cs
@@ -1,0 +1,15 @@
+﻿using System.Net.Http.Headers;
+using System.Text;
+
+namespace WebDav.Client.Core
+{
+    internal static class MediaTypes
+    {
+        internal static readonly MediaTypeHeaderValue XmlMediaType = new MediaTypeHeaderValue("application/xml")
+        {
+            CharSet = Encoding.UTF8.WebName
+        };
+
+        internal static readonly MediaTypeHeaderValue BinaryDataMediaType = new MediaTypeHeaderValue("application/octet-stream");
+    }
+}

--- a/src/WebDav.Client/Core/WebDavDispatcher.cs
+++ b/src/WebDav.Client/Core/WebDavDispatcher.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -47,8 +48,10 @@ namespace WebDav
                 if (requestParams.Content != null)
                 {
                     request.Content = requestParams.Content;
-                    if (!string.IsNullOrEmpty(requestParams.ContentType))
-                        request.Content.Headers.ContentType = new MediaTypeHeaderValue(requestParams.ContentType);
+                    if (requestParams.ContentType != null)
+                    {
+                        request.Content.Headers.ContentType = requestParams.ContentType;
+                    }
                 }
 
                 var response = await _httpClient.SendAsync(request, httpCompletionOption, cancellationToken).ConfigureAwait(false);

--- a/src/WebDav.Client/Request/LockParameters.cs
+++ b/src/WebDav.Client/Request/LockParameters.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.Http.Headers;
 using System.Threading;
+using WebDav.Client.Core;
 
 namespace WebDav
 {
@@ -14,6 +16,7 @@ namespace WebDav
         /// </summary>
         public LockParameters()
         {
+            ContentType = MediaTypes.XmlMediaType;
             Headers = new List<KeyValuePair<string, string>>();
             CancellationToken = CancellationToken.None;
         }
@@ -38,6 +41,12 @@ namespace WebDav
         /// Gets or sets the owner of this lock.
         /// </summary>
         public LockOwner Owner { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content type of the request body.
+        /// The default value is application/xml; charset=utf-8.
+        /// </summary>
+        public MediaTypeHeaderValue ContentType { get; set; }
 
         /// <summary>
         /// Gets or sets the collection of http request headers.

--- a/src/WebDav.Client/Request/PropfindParameters.cs
+++ b/src/WebDav.Client/Request/PropfindParameters.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Xml.Linq;
+using WebDav.Client.Core;
 
 namespace WebDav
 {
@@ -17,6 +19,7 @@ namespace WebDav
             RequestType = PropfindRequestType.AllProperties;
             CustomProperties = new List<XName>();
             Namespaces = new List<NamespaceAttr>();
+            ContentType = MediaTypes.XmlMediaType;
             Headers = new List<KeyValuePair<string, string>>();
             CancellationToken = CancellationToken.None;
         }
@@ -43,6 +46,12 @@ namespace WebDav
         /// It corresponds to the WebDAV Depth header.
         /// </summary>
         public ApplyTo.Propfind? ApplyTo { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content type of the request body.
+        /// The default value is application/xml; charset=utf-8.
+        /// </summary>
+        public MediaTypeHeaderValue ContentType { get; set; }
 
         /// <summary>
         /// Gets or sets the collection of http request headers.

--- a/src/WebDav.Client/Request/ProppatchParameters.cs
+++ b/src/WebDav.Client/Request/ProppatchParameters.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Net.Http.Headers;
 using System.Threading;
 using System.Xml.Linq;
+using WebDav.Client.Core;
 
 namespace WebDav
 {
@@ -17,6 +19,7 @@ namespace WebDav
             PropertiesToSet = new Dictionary<XName, string>();
             PropertiesToRemove = new List<XName>();
             Namespaces = new List<NamespaceAttr>();
+            ContentType = MediaTypes.XmlMediaType;
             Headers = new List<KeyValuePair<string, string>>();
             CancellationToken = CancellationToken.None;
         }
@@ -35,6 +38,12 @@ namespace WebDav
         /// Gets or sets the collection of xml namespaces of properties.
         /// </summary>
         public IReadOnlyCollection<NamespaceAttr> Namespaces { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content type of the request body.
+        /// The default value is application/xml; charset=utf-8.
+        /// </summary>
+        public MediaTypeHeaderValue ContentType { get; set; }
 
         /// <summary>
         /// Gets or sets the collection of http request headers.

--- a/src/WebDav.Client/Request/PutFileParameters.cs
+++ b/src/WebDav.Client/Request/PutFileParameters.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
+using System.Net.Http.Headers;
 using System.Threading;
+using WebDav.Client.Core;
 
 namespace WebDav
 {
@@ -13,7 +15,7 @@ namespace WebDav
         /// </summary>
         public PutFileParameters()
         {
-            ContentType = "application/octet-stream";
+            ContentType = MediaTypes.BinaryDataMediaType;
             Headers = new List<KeyValuePair<string, string>>();
             CancellationToken = CancellationToken.None;
         }
@@ -22,7 +24,7 @@ namespace WebDav
         /// Gets or sets the content type of the request body.
         /// The default value is application/octet-stream.
         /// </summary>
-        public string ContentType { get; set; }
+        public MediaTypeHeaderValue ContentType { get; set; }
 
         /// <summary>
         /// Gets or sets the resource lock token.

--- a/src/WebDav.Client/Request/RequestParameters.cs
+++ b/src/WebDav.Client/Request/RequestParameters.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace WebDav
 {
@@ -14,6 +15,6 @@ namespace WebDav
 
         public HttpContent Content { get; set; }
 
-        public string ContentType { get; set; }
+        public MediaTypeHeaderValue ContentType { get; set; }
     }
 }


### PR DESCRIPTION
This Pull Request addresses #56:
- making application/xml a default content-type for PROPFIND, PROPPATCH, LOCK and allowing to override it.
- changing ContentType type of PutFileParameters from string to MediaTypeHeaderValue.